### PR TITLE
add EOL tags to readme

### DIFF
--- a/.github/workflows/dockerimage-latest.yml
+++ b/.github/workflows/dockerimage-latest.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: 
       - master
-      - refactor
   workflow_dispatch:
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 - `latest` | `bl_3.2` *(Blender 3.2)*
 - `bl_2.93` *(Blender 2.93 LTS)*
+
+### EOL Tags
+
+- `bl_3.1` *(Blender 3.1)*
 - `bl_2.83` *(Blender 2.83 LTS)*
 
 [![Dockerimage builder](https://github.com/crowdrender/cr-docker/actions/workflows/dockerimage-latest.yml/badge.svg)](https://github.com/crowdrender/cr-docker/actions/workflows/dockerimage-latest.yml)


### PR DESCRIPTION
just a small maintenance update, which adds EOL tags to the readme including `3.1` and `2.83`.

I also removed the non existent `refactor` branch from the workflow script.